### PR TITLE
Disable `comment-no-empty` rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ module.exports = {
 	plugins: ['stylelint-scss'],
 	rules: {
 		'at-rule-no-unknown': null,
+		'comment-no-empty': null,
 		'no-invalid-position-at-import-rule': [
 			true,
 			{


### PR DESCRIPTION
According to the [`scss/comment-no-empty` README](https://github.com/stylelint-scss/stylelint-scss/blob/master/src/rules/comment-no-empty/README.md), we should disable the stylelint's `comment-no-empty` core rule when using the `scss/comment-no-empty` rule.