### PR TITLE
Set color-function-notation rule to 'legacy'

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ module.exports = {
 		'at-rule-no-unknown': null,
 		'comment-no-empty': null,
 		'function-no-unknown': null,
+    'color-function-notation': 'legacy',
 		'no-invalid-position-at-import-rule': [
 			true,
 			{


### PR DESCRIPTION
Sass hasn't caught up to the modern color functions standard, it would throw an error if the new function were used.
For more info see [this thread](https://stackoverflow.com/questions/66825515/getting-error-in-css-with-rgb0-0-0-15).