### PR TITLE
Allow `!default` annotation

### DIFF
--- a/__tests__/valid.scss
+++ b/__tests__/valid.scss
@@ -60,6 +60,7 @@
   color: #333;
 }
 
+$default-color: #000 !default;
 $local-color: #333;
 $fonts: "Tahoma", "Helvetica Neue", "Helvetica", sans-serif;
 $theme-colors: (

--- a/__tests__/valid.scss
+++ b/__tests__/valid.scss
@@ -68,8 +68,10 @@ $theme-colors: (
   "warning": #ffc107,
 );
 
+$global-variable: first global value;
 :root {
   --brand-red: hsl(5deg 10% 40%);
+  $global-variable: second global value !global;
 }
 
 .selector-1,

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ module.exports = {
 	customSyntax: require('postcss-scss'),
 	plugins: ['stylelint-scss'],
 	rules: {
+		'annotation-no-unknown': [true, { ignoreAnnotations: ['default'] }],
 		'at-rule-no-unknown': null,
 		'comment-no-empty': null,
 		'function-no-unknown': null,

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ module.exports = {
 	customSyntax: require('postcss-scss'),
 	plugins: ['stylelint-scss'],
 	rules: {
-		'annotation-no-unknown': [true, { ignoreAnnotations: ['default'] }],
+		'annotation-no-unknown': [true, { ignoreAnnotations: ['default', 'global'] }],
 		'at-rule-no-unknown': null,
 		'comment-no-empty': null,
 		'function-no-unknown': null,

--- a/index.js
+++ b/index.js
@@ -5,7 +5,12 @@ module.exports = {
 	customSyntax: require('postcss-scss'),
 	plugins: ['stylelint-scss'],
 	rules: {
-		'annotation-no-unknown': [true, { ignoreAnnotations: ['default', 'global'] }],
+		'annotation-no-unknown': [
+			true,
+			{
+				ignoreAnnotations: ['default', 'global'],
+			},
+		],
 		'at-rule-no-unknown': null,
 		'comment-no-empty': null,
 		'function-no-unknown': null,


### PR DESCRIPTION
This fixes stylelint-scss/stylelint-config-recommended-scss#131