### PR TITLE
Update package-lock.json to update peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
       },
       "peerDependencies": {
         "postcss": "^8.3.3",
-        "stylelint": "^14.4.0"
+        "stylelint": "^14.10.0"
       },
       "peerDependenciesMeta": {
         "postcss": {


### PR DESCRIPTION
This seemed to be missing in the last commit, which I noticed during testing locally for #132 .