### PR TITLE
Support @tailwind at-rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,12 @@ module.exports = {
 		'scss/at-if-no-null': true,
 		'scss/at-import-no-partial-leading-underscore': true,
 		'scss/at-import-partial-extension': 'never',
-		'scss/at-rule-no-unknown': true,
+		'scss/at-rule-no-unknown': [
+      true,
+      {
+        ignoreAtRules: ['tailwind'],
+      },
+    ],
 		'scss/comment-no-empty': true,
 		'scss/declaration-nested-properties-no-divided-groups': true,
 		'scss/dollar-variable-no-missing-interpolation': true,


### PR DESCRIPTION
Hi there, thanks for this configuration and all of the work in the SCSS ecosystem 🙌

Since Tailwind CSS is becoming very popular, would you consider configuring the `scss/at-rule-no-unknown` to ignore the `@tailwind` at-rules and not show an error about them?

Tradeoff:

- 👎 It's possible that it would cause some projects to break if they happened to incorrectly copy `@tailwind` into their SCSS (but then I'm guessing they would see a runtime error anyway?)
- 👍 `stylelint-config-recommended-scss` works out of the box with Tailwind CSS, no need to configure any other rules

Example error:

<img width="594" alt="Screenshot 2023-03-24 at 19 52 02" src="https://user-images.githubusercontent.com/1935696/227629069-225ba440-b234-436b-854f-298d953db314.png">

## Alternatives considered:

### Alternative 1

Override the configuration in every new project that uses `stylelint-config-recommended-scss` and Tailwind CSS:

```diff
/** @type { import('stylelint').Config } */
const config = {
  overrides: [
    {
      files: ['**/*.css', '**/*.scss', '**/*.sass', '**/*.less'],
      extends: ['stylelint-config-recommended-scss'],
+      rules: {
+        'scss/at-rule-no-unknown': [
+          true,
+          {
+            ignoreAtRules: ['tailwind'],
+          },
+        ],
      },
    },
  ],
};

module.exports = config;
```

### Alternative 2

Use something like [`stylelint-config-tailwindcss`](https://github.com/zhilidali/stylelint-config-tailwindcss) to override the rules from `stylelint-config-recommended-scss` (although it doesn't look like there is a published package that overrides the `scss/` rules currently... 🤔) - in every new project that uses `stylelint-config-recommended-scss` and Tailwind CSS