### PR TITLE
Fix false positive for nesting-selector-no-missing-scoping-root

### DIFF
--- a/__tests__/valid.scss
+++ b/__tests__/valid.scss
@@ -39,6 +39,10 @@ $postfix: if($infix != '', $infix + '-down', '');
   border-style: solid;
   border-width: math.div($size, 2);
 
+  &:hover {
+    transform: translate(0, 8px);
+  }
+
   @if $direction == up {
     border-bottom-color: $color;
   } @else if $direction == right {

--- a/index.js
+++ b/index.js
@@ -19,6 +19,12 @@ module.exports = {
 		'function-no-unknown': null,
 		'media-feature-name-value-no-unknown': null,
 		'media-query-no-invalid': null,
+		'nesting-selector-no-missing-scoping-root': [
+			true,
+			{
+				ignoreAtRules: ['mixin'],
+			},
+		],
 		'no-invalid-position-at-import-rule': [
 			true,
 			{

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,14 +22,14 @@
         "npm-run-all2": "^8.0.4",
         "prettier": "^3.6.2",
         "remark-cli": "^12.0.1",
-        "stylelint": "^16.23.1"
+        "stylelint": "^16.24.0"
       },
       "engines": {
         "node": ">=20"
       },
       "peerDependencies": {
         "postcss": "^8.3.3",
-        "stylelint": "^16.23.1"
+        "stylelint": "^16.24.0"
       },
       "peerDependenciesMeta": {
         "postcss": {
@@ -1785,13 +1785,13 @@
       }
     },
     "node_modules/cacheable": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-1.10.3.tgz",
-      "integrity": "sha512-M6p10iJ/VT0wT7TLIGUnm958oVrU2cUK8pQAVU21Zu7h8rbk/PeRtRWrvHJBql97Bhzk3g1N6+2VKC+Rjxna9Q==",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-1.10.4.tgz",
+      "integrity": "sha512-Gd7ccIUkZ9TE2odLQVS+PDjIvQCdJKUlLdJRVvZu0aipj07Qfx+XIej7hhDrKGGoIxV5m5fT/kOJNJPQhQneRg==",
       "license": "MIT",
       "dependencies": {
-        "hookified": "^1.10.0",
-        "keyv": "^5.4.0"
+        "hookified": "^1.11.0",
+        "keyv": "^5.5.0"
       }
     },
     "node_modules/cacheable/node_modules/keyv": {
@@ -3507,9 +3507,9 @@
       }
     },
     "node_modules/hookified": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/hookified/-/hookified-1.11.0.tgz",
-      "integrity": "sha512-aDdIN3GyU5I6wextPplYdfmWCo+aLmjjVbntmX6HLD5RCi/xKsivYEBhnRD+d9224zFf008ZpLMPlWF0ZodYZw==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/hookified/-/hookified-1.12.0.tgz",
+      "integrity": "sha512-hMr1Y9TCLshScrBbV2QxJ9BROddxZ12MX9KsCtuGGy/3SmmN5H1PllKerrVlSotur9dlE8hmUKAOSa3WDzsZmQ==",
       "license": "MIT"
     },
     "node_modules/hosted-git-info": {
@@ -8157,9 +8157,9 @@
       "dev": true
     },
     "node_modules/stylelint": {
-      "version": "16.23.1",
-      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.23.1.tgz",
-      "integrity": "sha512-dNvDTsKV1U2YtiUDfe9d2gp902veFeo3ecCWdGlmLm2WFrAV0+L5LoOj/qHSBABQwMsZPJwfC4bf39mQm1S5zw==",
+      "version": "16.24.0",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.24.0.tgz",
+      "integrity": "sha512-7ksgz3zJaSbTUGr/ujMXvLVKdDhLbGl3R/3arNudH7z88+XZZGNLMTepsY28WlnvEFcuOmUe7fg40Q3lfhOfSQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -8170,6 +8170,7 @@
           "url": "https://github.com/sponsors/stylelint"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "@csstools/css-parser-algorithms": "^3.0.5",
         "@csstools/css-tokenizer": "^3.0.4",
@@ -8184,7 +8185,7 @@
         "debug": "^4.4.1",
         "fast-glob": "^3.3.3",
         "fastest-levenshtein": "^1.0.16",
-        "file-entry-cache": "^10.1.3",
+        "file-entry-cache": "^10.1.4",
         "global-modules": "^2.0.0",
         "globby": "^11.1.0",
         "globjoin": "^0.1.4",
@@ -8297,23 +8298,23 @@
       }
     },
     "node_modules/stylelint/node_modules/file-entry-cache": {
-      "version": "10.1.3",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-10.1.3.tgz",
-      "integrity": "sha512-D+w75Ub8T55yor7fPgN06rkCAUbAYw2vpxJmmjv/GDAcvCnv9g7IvHhIZoxzRZThrXPFI2maeY24pPbtyYU7Lg==",
+      "version": "10.1.4",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-10.1.4.tgz",
+      "integrity": "sha512-5XRUFc0WTtUbjfGzEwXc42tiGxQHBmtbUG1h9L2apu4SulCGN3Hqm//9D6FAolf8MYNL7f/YlJl9vy08pj5JuA==",
       "license": "MIT",
       "dependencies": {
-        "flat-cache": "^6.1.12"
+        "flat-cache": "^6.1.13"
       }
     },
     "node_modules/stylelint/node_modules/flat-cache": {
-      "version": "6.1.12",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.12.tgz",
-      "integrity": "sha512-U+HqqpZPPXP5d24bWuRzjGqVqUcw64k4nZAbruniDwdRg0H10tvN7H6ku1tjhA4rg5B9GS3siEvwO2qjJJ6f8Q==",
+      "version": "6.1.13",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.13.tgz",
+      "integrity": "sha512-gmtS2PaUjSPa4zjObEIn4WWliKyZzYljgxODBfxugpK6q6HU9ClXzgCJ+nlcPKY9Bt090ypTOLIFWkV0jbKFjw==",
       "license": "MIT",
       "dependencies": {
-        "cacheable": "^1.10.3",
+        "cacheable": "^1.10.4",
         "flatted": "^3.3.3",
-        "hookified": "^1.10.0"
+        "hookified": "^1.11.0"
       }
     },
     "node_modules/stylelint/node_modules/ignore": {
@@ -10677,12 +10678,12 @@
       }
     },
     "cacheable": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-1.10.3.tgz",
-      "integrity": "sha512-M6p10iJ/VT0wT7TLIGUnm958oVrU2cUK8pQAVU21Zu7h8rbk/PeRtRWrvHJBql97Bhzk3g1N6+2VKC+Rjxna9Q==",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-1.10.4.tgz",
+      "integrity": "sha512-Gd7ccIUkZ9TE2odLQVS+PDjIvQCdJKUlLdJRVvZu0aipj07Qfx+XIej7hhDrKGGoIxV5m5fT/kOJNJPQhQneRg==",
       "requires": {
-        "hookified": "^1.10.0",
-        "keyv": "^5.4.0"
+        "hookified": "^1.11.0",
+        "keyv": "^5.5.0"
       },
       "dependencies": {
         "keyv": {
@@ -11827,9 +11828,9 @@
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
     },
     "hookified": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/hookified/-/hookified-1.11.0.tgz",
-      "integrity": "sha512-aDdIN3GyU5I6wextPplYdfmWCo+aLmjjVbntmX6HLD5RCi/xKsivYEBhnRD+d9224zFf008ZpLMPlWF0ZodYZw=="
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/hookified/-/hookified-1.12.0.tgz",
+      "integrity": "sha512-hMr1Y9TCLshScrBbV2QxJ9BROddxZ12MX9KsCtuGGy/3SmmN5H1PllKerrVlSotur9dlE8hmUKAOSa3WDzsZmQ=="
     },
     "hosted-git-info": {
       "version": "7.0.1",
@@ -14944,9 +14945,9 @@
       "dev": true
     },
     "stylelint": {
-      "version": "16.23.1",
-      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.23.1.tgz",
-      "integrity": "sha512-dNvDTsKV1U2YtiUDfe9d2gp902veFeo3ecCWdGlmLm2WFrAV0+L5LoOj/qHSBABQwMsZPJwfC4bf39mQm1S5zw==",
+      "version": "16.24.0",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.24.0.tgz",
+      "integrity": "sha512-7ksgz3zJaSbTUGr/ujMXvLVKdDhLbGl3R/3arNudH7z88+XZZGNLMTepsY28WlnvEFcuOmUe7fg40Q3lfhOfSQ==",
       "requires": {
         "@csstools/css-parser-algorithms": "^3.0.5",
         "@csstools/css-tokenizer": "^3.0.4",
@@ -14961,7 +14962,7 @@
         "debug": "^4.4.1",
         "fast-glob": "^3.3.3",
         "fastest-levenshtein": "^1.0.16",
-        "file-entry-cache": "^10.1.3",
+        "file-entry-cache": "^10.1.4",
         "global-modules": "^2.0.0",
         "globby": "^11.1.0",
         "globjoin": "^0.1.4",
@@ -15005,21 +15006,21 @@
           }
         },
         "file-entry-cache": {
-          "version": "10.1.3",
-          "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-10.1.3.tgz",
-          "integrity": "sha512-D+w75Ub8T55yor7fPgN06rkCAUbAYw2vpxJmmjv/GDAcvCnv9g7IvHhIZoxzRZThrXPFI2maeY24pPbtyYU7Lg==",
+          "version": "10.1.4",
+          "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-10.1.4.tgz",
+          "integrity": "sha512-5XRUFc0WTtUbjfGzEwXc42tiGxQHBmtbUG1h9L2apu4SulCGN3Hqm//9D6FAolf8MYNL7f/YlJl9vy08pj5JuA==",
           "requires": {
-            "flat-cache": "^6.1.12"
+            "flat-cache": "^6.1.13"
           }
         },
         "flat-cache": {
-          "version": "6.1.12",
-          "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.12.tgz",
-          "integrity": "sha512-U+HqqpZPPXP5d24bWuRzjGqVqUcw64k4nZAbruniDwdRg0H10tvN7H6ku1tjhA4rg5B9GS3siEvwO2qjJJ6f8Q==",
+          "version": "6.1.13",
+          "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.13.tgz",
+          "integrity": "sha512-gmtS2PaUjSPa4zjObEIn4WWliKyZzYljgxODBfxugpK6q6HU9ClXzgCJ+nlcPKY9Bt090ypTOLIFWkV0jbKFjw==",
           "requires": {
-            "cacheable": "^1.10.3",
+            "cacheable": "^1.10.4",
             "flatted": "^3.3.3",
-            "hookified": "^1.10.0"
+            "hookified": "^1.11.0"
           }
         },
         "ignore": {

--- a/package.json
+++ b/package.json
@@ -39,11 +39,11 @@
     "npm-run-all2": "^8.0.4",
     "prettier": "^3.6.2",
     "remark-cli": "^12.0.1",
-    "stylelint": "^16.23.1"
+    "stylelint": "^16.24.0"
   },
   "peerDependencies": {
     "postcss": "^8.3.3",
-    "stylelint": "^16.23.1"
+    "stylelint": "^16.24.0"
   },
   "peerDependenciesMeta": {
     "postcss": {


### PR DESCRIPTION
This PR fixes a false positive for `nesting-selector-no-missing-scoping-root` where parent selectors inside mixins would be considered as error even tho they are legal there (as long as the associated `@include` is used in a propper scope + SASS compiler will catch non-propper use anyway).

- Closes #364 