### PR TITLE
Revert stylelint peer dep version bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
       },
       "peerDependencies": {
         "postcss": "^8.3.3",
-        "stylelint": "^16.24.0"
+        "stylelint": "^16.23.1"
       },
       "peerDependenciesMeta": {
         "postcss": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "peerDependencies": {
     "postcss": "^8.3.3",
-    "stylelint": "^16.24.0"
+    "stylelint": "^16.23.1"
   },
   "peerDependenciesMeta": {
     "postcss": {


### PR DESCRIPTION
Reverting stylient peer dep (but not dev dep) version bump to keep the version in sync with "stylelint-config-recommended"